### PR TITLE
[wasm] Request persistent storage from browser & update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,14 @@ Star Control 2: The Ur-Quan Masters port to WebAssembly
 This is a fork of Star Control 2: The Ur-Quan Masters to WebAssembly
 for running in web browsers, using the Emscripten toolchain.
 
-Beware! In the WebAssembly build, **saved games are not** persistent, and the
-game has not received much testing. It is not fit for a full play-through, but
-currently merely a toy project.
+Save games and preferences are persisted on client-side using browser IndexedDB
+API (Emscripten IDBFS). Persistent storage will be requested when you save a
+game or change preferences. If persistent storage is unavailable, storage is on
+a best-effort basis; a warning message will be shown in this case.
+On Chrome and Safari, the website needs to be bookmarked enable persistent
+storage.
+[Read more about persistence](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#does_browser-stored_data_persist)
+
 
 Building in Docker
 ------------------
@@ -64,7 +69,6 @@ Then open in your web browser: http://localhost:9999/uqm-debug.html
 
 Known issues
 ------------
-* Gameplay: No support for persistent saved games.
 * Audio: Firefox doesn't play some samples (e.g. menu ping), but works in Chrome
 * Audio: MixSDL does not work (OpenAL works)
 * Threading: SDL threading does not work (pthreads work)

--- a/sc2/wasm/pre.js
+++ b/sc2/wasm/pre.js
@@ -29,7 +29,7 @@ Module.preRun.push(() => {
 
         if (!persistRequested) {
             requestPersistentStorage().catch(err => {
-                alert("Warning: Browser may delete saved game & preferences after inactivity.\n" + err);
+                alert("Warning: Browser may delete saved games & preferences after inactivity.\n" + err);
             });
             persistRequested = true;
         }
@@ -41,7 +41,7 @@ Module.preRun.push(() => {
     FS.mount(IDBFS, {}, "/home/web_user/.uqm");
     FS.syncfs( /*populate=*/ true, err => {
         if (err) {
-            alert("Populating from IndexedDB failed, saved games & preferences will not be persistent.\n" + err);
+            alert("Populating from IndexedDB failed, saved game & preferences will not be persistent.\n" + err);
         } else {
             removeRunDependency("syncfs");
             console.log("Loaded files from browser IndexedDB.");

--- a/sc2/wasm/pre.js
+++ b/sc2/wasm/pre.js
@@ -21,7 +21,7 @@ Module.preRun.push(() => {
     window.wasm_syncfs = () => {
         FS.syncfs( /*populate=*/ false, err => {
             if (err) {
-                alert("Saving to IndexedDB failed, saved games & preferences will not be persistent.\n" + err);
+                alert("Saving to IndexedDB failed, saved game & preferences will not be persistent.\n" + err);
             } else {
                 console.log("Saved files to browser IndexedDB.");
             }
@@ -29,7 +29,7 @@ Module.preRun.push(() => {
 
         if (!persistRequested) {
             requestPersistentStorage().catch(err => {
-                alert("Warning: Browser may delete saved games & preferences after inactivity.\n" + err);
+                alert("Warning: Browser may delete saved game & preferences after inactivity.\n" + err);
             });
             persistRequested = true;
         }

--- a/sc2/wasm/pre.js
+++ b/sc2/wasm/pre.js
@@ -1,14 +1,38 @@
 Module.preRun ||= [];
 
-Module.preRun.push(function () {
+Module.preRun.push(() => {
+    let persistRequested = false;
+
+    function requestPersistentStorage() {
+        if (navigator.storage && navigator.storage.persist) {
+            return navigator.storage.persist().then(isPersisted => {
+                if (isPersisted) {
+                    console.log("Persistent storage request was accepted.");
+                } else {
+                    throw "Persistent storage request was rejected.";
+                }
+            });
+        } else {
+            return Promise.reject("Persistent storage not supported by browser.");
+        }
+    }
+
+    // Called from C code: uio_fclose()
     window.wasm_syncfs = () => {
         FS.syncfs( /*populate=*/ false, err => {
             if (err) {
-                alert("Saving to IndexedDB failed, saved game & preferences will not be persistent.\n" + err);
+                alert("Saving to IndexedDB failed, saved games & preferences will not be persistent.\n" + err);
             } else {
                 console.log("Saved files to browser IndexedDB.");
             }
         });
+
+        if (!persistRequested) {
+            requestPersistentStorage().catch(err => {
+                alert("Warning: Browser may delete saved games & preferences after inactivity.\n" + err);
+            });
+            persistRequested = true;
+        }
     };
 
     addRunDependency("syncfs");
@@ -17,7 +41,7 @@ Module.preRun.push(function () {
     FS.mount(IDBFS, {}, "/home/web_user/.uqm");
     FS.syncfs( /*populate=*/ true, err => {
         if (err) {
-            alert("Populating from IndexedDB failed, saved game & preferences will not be persistent.\n" + err);
+            alert("Populating from IndexedDB failed, saved games & preferences will not be persistent.\n" + err);
         } else {
             removeRunDependency("syncfs");
             console.log("Loaded files from browser IndexedDB.");

--- a/sc2/wasm/pre.js
+++ b/sc2/wasm/pre.js
@@ -1,6 +1,6 @@
 Module.preRun ||= [];
 
-Module.preRun.push(() => {
+Module.preRun.push(function () {
     let persistRequested = false;
 
     function requestPersistentStorage() {


### PR DESCRIPTION
* Request persistent storage using `navigator.storage.persist()`. [More information here](https://developer.mozilla.org/en-US/docs/Web/API/Storage_API/Storage_quotas_and_eviction_criteria#does_browser-stored_data_persist).
* Warn user when persistent storage is unavailable.
* Update README about persisted saves and preferences.

Related issue: #4
